### PR TITLE
Remove translation for subject as it includes {{ trans }}

### DIFF
--- a/2.3.7-p2/module-email/APSB22-48-CVE-2022-35698.patch
+++ b/2.3.7-p2/module-email/APSB22-48-CVE-2022-35698.patch
@@ -1,0 +1,11 @@
+--- a/Model/Template.php	2022-10-14 13:27:22.086388906 +0200
++++ b/Model/Template.php	2022-10-14 13:30:06.581879555 +0200
+@@ -252,7 +252,7 @@
+         );
+ 
+         try {
+-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
++            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+         } catch (\Exception $e) {
+             $this->cancelDesignConfig();
+             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);

--- a/2.3.7-p3/module-email/APSB22-48-CVE-2022-35698.patch
+++ b/2.3.7-p3/module-email/APSB22-48-CVE-2022-35698.patch
@@ -1,0 +1,11 @@
+--- a/Model/Template.php	2022-10-14 13:27:22.086388906 +0200
++++ b/Model/Template.php	2022-10-14 13:30:06.581879555 +0200
+@@ -252,7 +252,7 @@
+         );
+ 
+         try {
+-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
++            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+         } catch (\Exception $e) {
+             $this->cancelDesignConfig();
+             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);

--- a/2.3.7-p4/module-email/APSB22-48-CVE-2022-35698.patch
+++ b/2.3.7-p4/module-email/APSB22-48-CVE-2022-35698.patch
@@ -1,0 +1,11 @@
+--- a/Model/Template.php	2022-10-14 13:27:22.086388906 +0200
++++ b/Model/Template.php	2022-10-14 13:30:06.581879555 +0200
+@@ -252,7 +252,7 @@
+         );
+ 
+         try {
+-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
++            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+         } catch (\Exception $e) {
+             $this->cancelDesignConfig();
+             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);

--- a/2.4.1/module-email/APSB22-48-CVE-2022-35698.patch
+++ b/2.4.1/module-email/APSB22-48-CVE-2022-35698.patch
@@ -1,0 +1,11 @@
+--- a/Model/Template.php	2022-10-14 13:27:22.086388906 +0200
++++ b/Model/Template.php	2022-10-14 13:30:06.581879555 +0200
+@@ -252,7 +252,7 @@
+         );
+ 
+         try {
+-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
++            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+         } catch (\Exception $e) {
+             $this->cancelDesignConfig();
+             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);

--- a/2.4.2-p1/module-email/APSB22-48-CVE-2022-35698.patch
+++ b/2.4.2-p1/module-email/APSB22-48-CVE-2022-35698.patch
@@ -1,0 +1,11 @@
+--- a/Model/Template.php	2022-10-14 13:27:22.086388906 +0200
++++ b/Model/Template.php	2022-10-14 13:30:06.581879555 +0200
+@@ -252,7 +252,7 @@
+         );
+ 
+         try {
+-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
++            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+         } catch (\Exception $e) {
+             $this->cancelDesignConfig();
+             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);

--- a/2.4.2-p2/module-email/APSB22-48-CVE-2022-35698.patch
+++ b/2.4.2-p2/module-email/APSB22-48-CVE-2022-35698.patch
@@ -1,0 +1,11 @@
+--- a/Model/Template.php	2022-10-14 13:27:22.086388906 +0200
++++ b/Model/Template.php	2022-10-14 13:30:06.581879555 +0200
+@@ -252,7 +252,7 @@
+         );
+ 
+         try {
+-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
++            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+         } catch (\Exception $e) {
+             $this->cancelDesignConfig();
+             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);

--- a/2.4.3-p1/module-email/APSB22-48-CVE-2022-35698.patch
+++ b/2.4.3-p1/module-email/APSB22-48-CVE-2022-35698.patch
@@ -1,0 +1,11 @@
+--- a/Model/Template.php	2022-10-14 13:27:22.086388906 +0200
++++ b/Model/Template.php	2022-10-14 13:30:06.581879555 +0200
+@@ -252,7 +252,7 @@
+         );
+ 
+         try {
+-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
++            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+         } catch (\Exception $e) {
+             $this->cancelDesignConfig();
+             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);


### PR DESCRIPTION
For one occasion in the `module-email` a translation is forced, thus resulting in passing on a `Phrase` object onto the `filter` function. This is already fixed in 2.4.5, but this patch will also do for the other versions.