### PR TITLE
Remove translation for subject as it includes {{ trans }}

### DIFF
--- a/2.4.3-p2/module-email/APSB22-48-CVE-2022-35698.patch
+++ b/2.4.3-p2/module-email/APSB22-48-CVE-2022-35698.patch
@@ -1,0 +1,11 @@
+--- a/Model/Template.php	2022-10-14 13:27:22.086388906 +0200
++++ b/Model/Template.php	2022-10-14 13:30:06.581879555 +0200
+@@ -246,7 +247,7 @@
+         );
+ 
+         try {
+-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
++            $processedResult = $processor->setStoreId($storeId)->filter($this->getTemplateSubject());
+         } catch (\Exception $e) {
+             $this->cancelDesignConfig();
+             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);


### PR DESCRIPTION
This just copies the module-email patches from #8 to the 2.4.3-p2 version directory to resolve issues with emails being sent with subjects of "We're sorry, an error has occurred while generating this content."