### PR TITLE
Update module-customer patch for Magento 2.4.1

### DIFF
--- a/2.4.1/module-customer/APSB22-48-CVE-2022-35698.patch
+++ b/2.4.1/module-customer/APSB22-48-CVE-2022-35698.patch
@@ -6,15 +6,15 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 diff --git a/etc/webapi_rest/di.xml b/etc/webapi_rest/di.xml
 --- a/etc/webapi_rest/di.xml
 +++ b/etc/webapi_rest/di.xml	(date 1665735205046)
-@@ -31,6 +31,9 @@
+@@ -22,6 +25,9 @@
              </argument>
          </arguments>
      </type>
 +    <type name="Magento\Webapi\Controller\Rest\ParamsOverrider">
 +        <plugin name="validateCustomerData" type="Magento\Customer\Plugin\Webapi\Controller\Rest\ValidateCustomerData" sortOrder="1" disabled="false" />
 +    </type>
-     <preference for="Magento\Customer\Api\AccountManagementInterface"
-                 type="Magento\Customer\Model\AccountManagementApi" />
+     <type name="Magento\Customer\Api\CustomerRepositoryInterface">
+       <plugin name="updateCustomerByIdFromRequest" type="Magento\Customer\Model\Plugin\UpdateCustomer" />
  </config>
 Index: Plugin/Webapi/Controller/Rest/ValidateCustomerData.php
 IDEA additional info:


### PR DESCRIPTION
The provided patch didn't seem to work for Magento 2.4.1, the di.xml used to create the patch wasn't correct.